### PR TITLE
Do not specify depencency versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ npm install eslint-config-trustpilot --save-dev
 ```
 
 You must also `npm install` the following peer dependencies:
-- `eslint@2.x` (obviously)
-- `babel-eslint@5.x`
-- `eslint-plugin-babel@3.x`
+- `eslint` (obviously)
+- `babel-eslint`
+- `eslint-plugin-babel`
 
 The browser config additionally requires:
-- `eslint-plugin-html@1.x`
+- `eslint-plugin-html`
 
 The React config additionally requires:
-- `eslint-plugin-react@5.x`
+- `eslint-plugin-react`
 
 ## Getting Started
 


### PR DESCRIPTION
All the dependency versions referenced in the README are obsolete (eslint is at v4, babel-eslint is at v8, eslint-plugin-babel is at v4, eslint-plugin-html is at v4 and eslint-plugin-react is at v7). Moreover, installing eslint@2 and running the linting script will lead to errors (the one we had was that the comma-dangle rule is not configured properly). 
We're at the business website team use all the latest versions of the said deps, and it all works nicely for us. Perhaps it's best not to specify any particular dependency versions in the README at all.